### PR TITLE
fix for combined metadata package location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Yumsync CHANGELOG
 =================
 
+v0.1.2 (2016-01-21)
+-------------------
+
+* Fix metadata generate for combined metadata (was referencing packages in the versioned directory)
+
 v0.1.1 (2016-01-20)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ required_module('createrepo')
 #required_module('pyliblzma')
 
 setup(name='yumsync',
-    version='0.1.1',
+    version='0.1.2',
     description='A tool for mirroring and versioning YUM repositories',
     author='Ryan Uber, Vamegh Hedayati, Jordan Wesolowski',
     author_email='ru@ryanuber.com, repo@ev9.io, jrwesolo@gmail.com',

--- a/yumsync/__init__.py
+++ b/yumsync/__init__.py
@@ -6,7 +6,7 @@ import urlparse
 from yumsync import util, repo, progress
 from yumsync.log import log
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 def localsync(repos={}, basedir=None, repoversion=None, link_type=None, callback=None):
   """ Create Repo Metadata from Local package repo

--- a/yumsync/repo.py
+++ b/yumsync/repo.py
@@ -76,15 +76,6 @@ def create_metadata(repo, packages=None, comps=None, checksum=None):
     if comps and os.path.exists(groupdir):
         shutil.rmtree(groupdir)
 
-def create_combined_metadata(repo, package_dir, comps=None, checksum=None):
-    """ Creates YUM metadata for the entire Packages directory.
-
-    When used with versioning, this creates a combined repository of all
-    packages ever synced for the repository.
-    """
-    combined_repo = set_path(repo, package_dir)
-    create_metadata(combined_repo, None, comps, checksum)
-
 def retrieve_group_comps(repo):
     """ Retrieve group comps XML data from a remote repository.
 
@@ -167,7 +158,8 @@ def localsync(repo, dest, local_dir, checksum, version, stable, link_type, delet
 
     if version:
         if combine:
-            create_combined_metadata(repo, package_dir, None, checksum)
+            repo = set_path(repo, package_dir)
+            create_metadata(repo, pkglist, None, checksum)
         elif os.path.exists(os.path.join(dest, 'repodata')):
             # At this point the combined metadata is stale, so remove it.
             shutil.rmtree(os.path.join(dest, 'repodata'))
@@ -294,7 +286,8 @@ def sync(repo, dest, checksum, version, stable, link_type, delete, combine=False
 
     if version:
         if combine:
-            create_combined_metadata(repo, package_dir, comps, checksum)
+            repo = set_path(repo, package_dir)
+            create_metadata(repo, pkglist, comps, checksum)
         elif os.path.exists(os.path.join(dest, 'repodata')):
             # At this point the combined metadata is stale, so remove it.
             shutil.rmtree(os.path.join(dest, 'repodata'))


### PR DESCRIPTION
Combined metadata was referencing packages in the versioned directory.
